### PR TITLE
Fixing line breaks in the message caused by partial writes to stderr

### DIFF
--- a/src/TeamCityFormatter.php
+++ b/src/TeamCityFormatter.php
@@ -160,11 +160,13 @@ class TeamCityFormatter implements Formatter
      */
     public function printEvent($eventName, $params = [])
     {
-        $this->printText("##teamcity[$eventName");
+        $message = "##teamcity[$eventName";
         foreach ($params as $key => $value) {
-            $this->printText(" $key='".str_replace("'", "\"", $value)."'");
+            $message .= " $key='".str_replace("'", "\"", $value)."'";
         }
-        $this->printText("]\n");
+        $message .= "]\n";
+
+        $this->printText($message);
     }
 
     /**


### PR DESCRIPTION
For some reason file_put_contents to stderr added \n each time it was called on our system (php 5.3, linux). So teamcity was not able to parse the message. I didn't looked into it in more detail why it is appending \n, but writing the message in one go works fine and doesn't break anything for systems where it was already working.
