### PR TITLE
Outputting to stdout instead of stderr

### DIFF
--- a/src/TeamCityFormatter.php
+++ b/src/TeamCityFormatter.php
@@ -172,6 +172,6 @@ class TeamCityFormatter implements Formatter
      */
     public function printText($text)
     {
-        file_put_contents('php://stderr', $text);
+        file_put_contents('php://stdout', $text);
     }
 }


### PR DESCRIPTION
Was there a special reason writing to stderr instead of stdout? It's nothing critical, but it feels cleaner to me not writing the full test output to stderr. Also, with our teamcity configuration "[err :: ...]" is prepended for each log line written to stderr, don't know if it is the same with your tc installation. I tested it with stdout and it's working fine.
