### PR TITLE
Updated console output printer.

### DIFF
--- a/src/TeamCityFormatter.php
+++ b/src/TeamCityFormatter.php
@@ -5,7 +5,7 @@ use Behat\Behat\EventDispatcher\Event\AfterStepTested;
 use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
 use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
 use Behat\Behat\EventDispatcher\Event\BeforeScenarioTested;
-use Behat\Behat\Output\Printer\ConsoleOutputPrinter;
+use Behat\Behat\Output\Printer\ConsoleOutputFactory;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Printer\OutputPrinter;
@@ -41,11 +41,11 @@ class TeamCityFormatter implements Formatter
     public static function getSubscribedEvents()
     {
         return array(
-            'tester.feature_tested.before'=>'onBeforeFeatureTested',
-            'tester.feature_tested.after'=>'onAfterFeatureTested',
-            'tester.scenario_tested.before'=>'onBeforeScenarioTested',
-            'tester.scenario_tested.after'=>'onAfterScenarioTested',
-            'tester.step_tested.after'=>'onAfterStepTested',
+          'tester.feature_tested.before'=>'onBeforeFeatureTested',
+          'tester.feature_tested.after'=>'onAfterFeatureTested',
+          'tester.scenario_tested.before'=>'onBeforeScenarioTested',
+          'tester.scenario_tested.after'=>'onAfterScenarioTested',
+          'tester.step_tested.after'=>'onAfterStepTested',
         );
     }
 
@@ -76,7 +76,7 @@ class TeamCityFormatter implements Formatter
      */
     public function getOutputPrinter()
     {
-        return new ConsoleOutputPrinter();
+        return new ConsoleOutputFactory();
     }
 
     /**


### PR DESCRIPTION
This will fix the console error of missing printer class
 `Fatal error: Class 'Behat\TeamCity\ConsoleOutputPrinter' not found`
